### PR TITLE
Add additional properties to transactional messages

### DIFF
--- a/MailJet.Client.Tests/SendMail.cs
+++ b/MailJet.Client.Tests/SendMail.cs
@@ -45,6 +45,10 @@ namespace MailJet.Client.Tests
                 new Dictionary<string, object>()
                 {
                     { "FirstName", "Test User Param" }
+                },
+                new Dictionary<string, string>()
+                {
+                   {"Mj-CustomID", "ID123"}
                 });
         }
 

--- a/MailJetClient/MailJetClient.cs
+++ b/MailJetClient/MailJetClient.cs
@@ -181,14 +181,14 @@ namespace MailJet.Client
             ExecuteRequest(request);
         }
 
-        public Response<DataItem> SendTemplateMessage(long TemplateId, MailAddress To, MailAddress From, string Subject, Dictionary<string, object> Parameters = null)
+        public Response<DataItem> SendTemplateMessage(long TemplateId, MailAddress To, MailAddress From, string Subject, Dictionary<string, object> Parameters = null, Dictionary<string, string> Properties = null)
         {
-            return SendTemplateMessage(TemplateId, new MailAddress[] { To }, From, Subject, Parameters);
+            return SendTemplateMessage(TemplateId, new MailAddress[] { To }, From, Subject, Parameters, Properties);
         }
 
         public String TemplateErrorReporting { get; set; }
 
-        public Response<DataItem> SendTemplateMessage(long TemplateId, MailAddress[] To, MailAddress From, string Subject, Dictionary<string, object> Parameters = null)
+        public Response<DataItem> SendTemplateMessage(long TemplateId, MailAddress[] To, MailAddress From, string Subject, Dictionary<string, object> Parameters = null, Dictionary<string, string> Properties = null)
         {
             if (To == null || To.Any(x => String.IsNullOrWhiteSpace(x.Address)))
                 throw new ArgumentNullException("To", "You must specify the recipient address");
@@ -218,6 +218,14 @@ namespace MailJet.Client
                 o.Add("FromName", From.DisplayName);
 
             o.Add("Recipients", JToken.FromObject(To, NewtonsoftJsonSerializer.Default.Serializer));
+
+            if (Properties != null && Properties.Any())
+            {
+                foreach (var p in Properties)
+                {
+                    o.Add(p.Key, p.Value);
+                }
+            }
 
             if (Parameters != null && Parameters.Any())
             {


### PR DESCRIPTION
Used to send additional `Mj-*` properties in transactional email.

I needed to send more properties on a transactional send. After coding this, I saw that #21 included one of the additional properties (but not all). It's up to you on the approach you would want to take. One option is just to create class properties for each of the `Mj-*` options documented in the link below. Another is to expose the common ones and keep an optional way to add additional ones. I'm happy to modify this to match the style of #21. 

See (https://dev.mailjet.com/guides/#send-api-json-properties) for options.