### PR TITLE
Add an explanation when receiving an HTTP 401 exception

### DIFF
--- a/MailJetClient/MailJetClient.cs
+++ b/MailJetClient/MailJetClient.cs
@@ -651,6 +651,9 @@ namespace MailJet.Client
             if (result.ResponseStatus == ResponseStatus.Completed && (result.StatusCode == HttpStatusCode.NoContent))
                 return null;
 
+            if (result.ResponseStatus == ResponseStatus.Completed && result.StatusCode == HttpStatusCode.Unauthorized)
+                throw new UnauthorizedAccessException("MailJet returned an HTTP 401 exception, please check your credentials");
+
             var error = JsonConvert.DeserializeObject<ErrorResponse>(result.Content);
             if (!String.IsNullOrWhiteSpace(error.ErrorInfo) || !String.IsNullOrWhiteSpace(error.ErrorMessage))
                 throw new Exception(String.Format("{0}\n{1}", error.ErrorMessage, error.ErrorMessage));


### PR DESCRIPTION
Hi,

Thanks for the library, it's been a great help :)

I discovered that I was using the wrong key/secret when trying to send emails, but the error I received was NullReferenceException, which took a while to figure out (since the result gets an empty Content field in this case, it gets deserialized to null). 

So I added a check to SendMessage(RestRequest request) to detect HTTP 401's and add an explanation.

Happy to change this if you think there's a better way of informing users of invalid credentials.

Cheers,
Mat